### PR TITLE
Numeric limits

### DIFF
--- a/include/numeric_limits.h
+++ b/include/numeric_limits.h
@@ -22,24 +22,31 @@ namespace alx {
     }
 
     NUM_LIM_INST(bool, false, true, true);
+
     NUM_LIM_INST(char, CHAR_MIN < 0, true, true);
     NUM_LIM_INST(signed char, true, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
-    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(unsigned char, false, true, true);
+
+    NUM_LIM_INST(short, false, true, true);
+    NUM_LIM_INST(unsigned short, false, true, true);
+
+    NUM_LIM_INST(int, false, true, true);
+    NUM_LIM_INST(unsigned, false, true, true);
+
+    NUM_LIM_INST(long, false, true, true);
+    NUM_LIM_INST(unsigned long, false, true, true);
+
+    NUM_LIM_INST(long long, false, true, true);
+    NUM_LIM_INST(unsigned long long, false, true, true);
+
+    NUM_LIM_INST(char8_t, false, true, true);
+    NUM_LIM_INST(char16_t, false, true, true);
+    NUM_LIM_INST(char32_t, false, true, true);
+    NUM_LIM_INST(wchar_t, false, true, true);
+
+    NUM_LIM_INST(float, true, false, false);
+    NUM_LIM_INST(double, true, false, false);
+    NUM_LIM_INST(long double, true, false, false);
 
 #undef NUM_LIM_INST
 } // namespace alx

--- a/include/numeric_limits.h
+++ b/include/numeric_limits.h
@@ -27,16 +27,16 @@ namespace alx {
     NUM_LIM_INST(signed char, true, true, true);
     NUM_LIM_INST(unsigned char, false, true, true);
 
-    NUM_LIM_INST(short, false, true, true);
+    NUM_LIM_INST(short, true, true, true);
     NUM_LIM_INST(unsigned short, false, true, true);
 
-    NUM_LIM_INST(int, false, true, true);
+    NUM_LIM_INST(int, true, true, true);
     NUM_LIM_INST(unsigned, false, true, true);
 
-    NUM_LIM_INST(long, false, true, true);
+    NUM_LIM_INST(long, true, true, true);
     NUM_LIM_INST(unsigned long, false, true, true);
 
-    NUM_LIM_INST(long long, false, true, true);
+    NUM_LIM_INST(long long, true, true, true);
     NUM_LIM_INST(unsigned long long, false, true, true);
 
     NUM_LIM_INST(char8_t, false, true, true);

--- a/include/numeric_limits.h
+++ b/include/numeric_limits.h
@@ -1,0 +1,47 @@
+#ifndef NUMERIC_LIMITS_H
+#define NUMERIC_LIMITS_H
+
+#include <limits.h>
+
+namespace alx {
+    template<typename T>
+    struct numeric_limits {
+        static constexpr bool is_specialized{false};
+        static constexpr bool is_signed{false};
+        static constexpr bool is_integer{false};
+        static constexpr bool is_exact{false};
+    };
+
+#define NUM_LIM_INST(TYPE, HAS_SIGN, IS_INT, EXACT)                                                \
+    template<>                                                                                     \
+    struct numeric_limits<TYPE> {                                                                  \
+        static constexpr bool is_specialized{true};                                                \
+        static constexpr bool is_signed{HAS_SIGN};                                                 \
+        static constexpr bool is_integer{IS_INT};                                                  \
+        static constexpr bool is_exact{EXACT};                                                     \
+    }
+
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(char, CHAR_MIN < 0, true, true);
+    NUM_LIM_INST(signed char, true, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+    NUM_LIM_INST(bool, false, true, true);
+
+#undef NUM_LIM_INST
+} // namespace alx
+
+#endif

--- a/include/type_traits.h
+++ b/include/type_traits.h
@@ -1,6 +1,8 @@
 #ifndef TYPE_TRAITS_H
 #define TYPE_TRAITS_H
 
+#include "numeric_limits.h"
+
 namespace alx {
 
     template<typename T, typename U>
@@ -35,7 +37,7 @@ namespace alx {
 
     template<typename T>
     struct is_integral {
-        static constexpr bool value{false};
+        static constexpr bool value{numeric_limits<T>::is_integer};
     };
     template<typename T>
     struct is_integral<const T> {
@@ -50,74 +52,6 @@ namespace alx {
         static constexpr bool value{is_integral<T>::value};
     };
 
-    template<>
-    struct is_integral<bool> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<char8_t> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<char16_t> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<char32_t> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<wchar_t> {
-        static constexpr bool value{true};
-    };
-
-    template<>
-    struct is_integral<char> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<short> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<int> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<long> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<long long> {
-        static constexpr bool value{true};
-    };
-
-    template<>
-    struct is_integral<unsigned char> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<unsigned short> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<unsigned int> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<unsigned long> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_integral<unsigned long long> {
-        static constexpr bool value{true};
-    };
-
-    template<>
-    struct is_integral<signed char> {
-        static constexpr bool value{true};
-    };
-
     template<typename T>
     constexpr bool is_integral_v = is_integral<T>::value;
 
@@ -125,19 +59,7 @@ namespace alx {
 
     template<typename T>
     struct is_arithmetic {
-        static constexpr bool value{is_integral_v<T>};
-    };
-    template<>
-    struct is_arithmetic<float> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_arithmetic<double> {
-        static constexpr bool value{true};
-    };
-    template<>
-    struct is_arithmetic<long double> {
-        static constexpr bool value{true};
+        static constexpr bool value{numeric_limits<T>::is_specialized};
     };
 
     template<typename T>
@@ -145,33 +67,7 @@ namespace alx {
 
     template<typename T, bool = is_arithmetic_v<T>>
     struct is_signed {
-        static constexpr bool value{T{-1} < T{0}};
-    };
-
-    template<>
-    struct is_signed<unsigned char> {
-        static constexpr bool value{false};
-    };
-    template<>
-    struct is_signed<unsigned short> {
-        static constexpr bool value{false};
-    };
-    template<>
-    struct is_signed<unsigned int> {
-        static constexpr bool value{false};
-    };
-    template<>
-    struct is_signed<unsigned long> {
-        static constexpr bool value{false};
-    };
-    template<>
-    struct is_signed<unsigned long long> {
-        static constexpr bool value{false};
-    };
-
-    template<typename T>
-    struct is_signed<T, false> {
-        static constexpr bool value{false};
+        static constexpr bool value{numeric_limits<T>::is_signed};
     };
 
     template<typename T>


### PR DESCRIPTION
Reduce the line count of the project overall, while providing a duplicate functionality. The reason for the duplication is that `type_traits` underpins the concepts and thus templates, while `numeric_limits` is information about a particular type.